### PR TITLE
bugfix: add conflict for warcraftlogsuploader

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,6 +7,7 @@ pkgrel=1
 pkgdesc="warcraftlogs.com desktop client for Linux"
 arch=('x86_64')
 depends=("fuse2")
+conflicts=("warcraftlogsuploader")
 url="https://warcraftlogs.com/"
 source=("$_pkgapp.AppImage::{{__source__}}"
         'start')


### PR DESCRIPTION
As this is an `-appimage` variant repo, conflict of base application should be flagged to ensure it is removed before install.

Removing conflicting old package:

``` 
» makepkg -i
==> Making package: warcraftlogsuploader-appimage 8.5.12-1 (Sat 08 Jun 2024 10:43:28 AM PDT)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Found warcraftlogsuploader.AppImage
  -> Found start
==> Validating source files with sha512sums...
    warcraftlogsuploader.AppImage ... Passed
    start ... Passed
==> Extracting sources...
==> Starting pkgver()...
==> WARNING: A package has already been built, installing existing package...
==> Installing package warcraftlogsuploader-appimage with pacman -U...
[sudo] password for smvoss: 
loading packages...
resolving dependencies...
looking for conflicting packages...
:: warcraftlogsuploader-appimage-8.5.12-1 and warcraftlogsuploader-6.0.1-1 are in conflict. Remove warcraftlogsuploader? [y/N] y

Packages (2) warcraftlogsuploader-6.0.1-1 [removal]  warcraftlogsuploader-appimage-8.5.12-1

Total Installed Size:  104.34 MiB
Net Upgrade Size:       95.01 MiB

:: Proceed with installation? [Y/n] y
(1/1) checking keys in keyring                                                                              [################################################################] 100%
(1/1) checking package integrity                                                                            [################################################################] 100%
(1/1) loading package files                                                                                 [################################################################] 100%
(1/1) checking for file conflicts                                                                           [################################################################] 100%
(2/2) checking available disk space                                                                         [################################################################] 100%
:: Processing package changes...
(1/1) removing warcraftlogsuploader                                                                         [################################################################] 100%
(1/1) installing warcraftlogsuploader-appimage                                                              [################################################################] 100%
:: Running post-transaction hooks...
(1/3) Arming ConditionNeedsUpdate...
(2/3) Updating icon theme caches...
(3/3) Updating the desktop file MIME type cache...
```